### PR TITLE
Remove dependency on the Miniion module.

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -5,10 +5,9 @@
     "displayName" : "Master Of Oreon",
     "description" : "Provides a manager interface for working with Terasology\nUse the 'O' key to toggle mouse grab so you can use the interface.",
     "dependencies" : [
-		{
-            "id" : "Miniion",
-            "minVersion" : "0.2.0"
-        }
+        {"id" : "Core", "minVersion" : "2.0.0"},
+        {"id" : "Oreons", "minVersion" : "0.2.0"},
+        {"id" : "ChangingBlocks", "minVersion" : "0.1.0"}
     ],
     "isServerSideOnly" : false
 }

--- a/src/main/java/org/terasology/managerInterface/ManagerInterfaceSystem.java
+++ b/src/main/java/org/terasology/managerInterface/ManagerInterfaceSystem.java
@@ -30,9 +30,9 @@ import org.terasology.logic.selection.ApplyBlockSelectionEvent;
 import org.terasology.managerInterface.nui.ManagerInterfaceHUDElement;
 import org.terasology.managerInterface.nui.ToggleMouseGrabberButton;
 import org.terasology.math.geom.Rect2f;
-import org.terasology.miniion.components.AssignedTaskType;
-import org.terasology.miniion.componentsystem.controllers.RevisedSimpleMinionAISystem;
-import org.terasology.miniion.componentsystem.controllers.TaskManagementSystem;
+//import org.terasology.miniion.components.AssignedTaskType;
+//import org.terasology.miniion.componentsystem.controllers.RevisedSimpleMinionAISystem;
+//import org.terasology.miniion.componentsystem.controllers.TaskManagementSystem;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
 import org.terasology.registry.Share;
@@ -53,9 +53,10 @@ public class ManagerInterfaceSystem extends BaseComponentSystem {
     }
     
     private ManagerCommandMode currentManagerCommandMode = ManagerCommandMode.None;
-    
-    @In 
-    private TaskManagementSystem taskManager;
+
+    //TODO Implement new TaskManagementSystem
+    //@In
+    //private TaskManagementSystem taskManager;
     
     @In
     private NUIManager nuiManager;
@@ -92,10 +93,10 @@ public class ManagerInterfaceSystem extends BaseComponentSystem {
                 // do nothing
                 break;
             case Plant:
-                taskManager.createAssignedTask(AssignedTaskType.Plant, event.getSelection());
+                //taskManager.createAssignedTask(AssignedTaskType.Plant, event.getSelection());
                 break;
             case Dig:
-                taskManager.createAssignedTask(AssignedTaskType.Dig, event.getSelection());
+                //taskManager.createAssignedTask(AssignedTaskType.Dig, event.getSelection());
                 break;
         }
     }

--- a/src/main/java/org/terasology/managerInterface/ManagerInterfaceSystem.java
+++ b/src/main/java/org/terasology/managerInterface/ManagerInterfaceSystem.java
@@ -30,9 +30,6 @@ import org.terasology.logic.selection.ApplyBlockSelectionEvent;
 import org.terasology.managerInterface.nui.ManagerInterfaceHUDElement;
 import org.terasology.managerInterface.nui.ToggleMouseGrabberButton;
 import org.terasology.math.geom.Rect2f;
-//import org.terasology.miniion.components.AssignedTaskType;
-//import org.terasology.miniion.componentsystem.controllers.RevisedSimpleMinionAISystem;
-//import org.terasology.miniion.componentsystem.controllers.TaskManagementSystem;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
 import org.terasology.registry.Share;
@@ -93,10 +90,9 @@ public class ManagerInterfaceSystem extends BaseComponentSystem {
                 // do nothing
                 break;
             case Plant:
-                //taskManager.createAssignedTask(AssignedTaskType.Plant, event.getSelection());
+                //requires task manager implementation
                 break;
             case Dig:
-                //taskManager.createAssignedTask(AssignedTaskType.Dig, event.getSelection());
                 break;
         }
     }

--- a/src/main/java/org/terasology/managerInterface/nui/ManagerInterfaceHUDElement.java
+++ b/src/main/java/org/terasology/managerInterface/nui/ManagerInterfaceHUDElement.java
@@ -24,7 +24,7 @@ import org.terasology.common.nui.UIToggleButton;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.prefab.PrefabManager;
 import org.terasology.managerInterface.ManagerInterfaceSystem;
-import org.terasology.registry.CoreRegistry;
+import org.terasology.registry.In;
 import org.terasology.rendering.nui.AbstractWidget;
 import org.terasology.rendering.nui.ControlWidget;
 import org.terasology.rendering.nui.CoreLayout;
@@ -38,6 +38,13 @@ import org.terasology.rendering.nui.widgets.ActivateEventListener;
 public class ManagerInterfaceHUDElement extends CoreHudWidget implements ControlWidget {
 
     private static final Logger logger = LoggerFactory.getLogger(ManagerInterfaceHUDElement.class);
+
+    @In
+    private EntityManager entityManager;
+    @In
+    private ManagerInterfaceSystem managerInterfaceSystem;
+    @In
+    private PrefabManager prefMan;
 
     private UIToggleButton designTabCommand;
     private UIToggleButton researchTabCommand;
@@ -154,7 +161,6 @@ public class ManagerInterfaceHUDElement extends CoreHudWidget implements Control
                 @Override
                 public void onActivated(UIWidget widget) {
                     selectToggleButtonInColumnLayout(designTab, widget);
-                    ManagerInterfaceSystem managerInterfaceSystem = CoreRegistry.get(ManagerInterfaceSystem.class);
                     managerInterfaceSystem.setPlantMode();
                 }
             });
@@ -169,7 +175,6 @@ public class ManagerInterfaceHUDElement extends CoreHudWidget implements Control
                 @Override
                 public void onActivated(UIWidget widget) {
                     selectToggleButtonInColumnLayout(designTab, widget);
-                    ManagerInterfaceSystem managerInterfaceSystem = CoreRegistry.get(ManagerInterfaceSystem.class);
                     managerInterfaceSystem.setDigMode();
                 }
             });
@@ -184,7 +189,6 @@ public class ManagerInterfaceHUDElement extends CoreHudWidget implements Control
                 @Override
                 public void onActivated(UIWidget widget) {
                     selectToggleButtonInColumnLayout(designTab, widget);
-                    ManagerInterfaceSystem managerInterfaceSystem = CoreRegistry.get(ManagerInterfaceSystem.class);
                     managerInterfaceSystem.setCutTreeMode();
                 }
             });
@@ -202,8 +206,6 @@ public class ManagerInterfaceHUDElement extends CoreHudWidget implements Control
             iterator.remove();
         }
 
-        PrefabManager prefMan = CoreRegistry.get(PrefabManager.class);
-
         //TODO Implement new MinionComponent and summon logic using Portals, currently SummonMinionMenuSystem has the spawn logic
     }
 
@@ -220,7 +222,6 @@ public class ManagerInterfaceHUDElement extends CoreHudWidget implements Control
             iterator.remove();
         }
 
-        EntityManager entityManager = CoreRegistry.get(EntityManager.class);
         //TODO A loop which lists out the Oreons that can be summoned
     }
 

--- a/src/main/java/org/terasology/managerInterface/nui/ManagerInterfaceHUDElement.java
+++ b/src/main/java/org/terasology/managerInterface/nui/ManagerInterfaceHUDElement.java
@@ -22,12 +22,8 @@ import org.slf4j.LoggerFactory;
 import org.terasology.common.nui.PickOneLayout;
 import org.terasology.common.nui.UIToggleButton;
 import org.terasology.entitySystem.entity.EntityManager;
-import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.prefab.PrefabManager;
 import org.terasology.managerInterface.ManagerInterfaceSystem;
-//import org.terasology.miniion.components.MinionComponent;
-//import org.terasology.miniion.nui.layers.SummonMinionMenuSystem;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.nui.AbstractWidget;
 import org.terasology.rendering.nui.ControlWidget;
@@ -209,26 +205,6 @@ public class ManagerInterfaceHUDElement extends CoreHudWidget implements Control
         PrefabManager prefMan = CoreRegistry.get(PrefabManager.class);
 
         //TODO Implement new MinionComponent and summon logic using Portals, currently SummonMinionMenuSystem has the spawn logic
-        /*for (final Prefab prefab : prefMan.listPrefabs(MinionComponent.class)) {
-
-            String[] tempstring = prefab.getName().split(":");
-            if (tempstring.length == 2) {
-                String minionName = tempstring[1];
-                UIToggleButton selectMinionMenu = new UIToggleButton();
-                selectMinionMenu.setText(minionName);
-                selectMinionMenu.subscribe(new ActivateEventListener() {
-                    @Override
-                    public void onActivated(UIWidget widget) {
-                        selectToggleButtonInColumnLayout(summonTab, widget);
-                        SummonMinionMenuSystem summonMinionMenuSystem = CoreRegistry.get(SummonMinionMenuSystem.class);
-                        summonMinionMenuSystem.createMinion(prefab);
-                    }
-
-                });
-
-                summonTabColumnLayout.addWidget(selectMinionMenu);
-            }
-        }*/
     }
 
     // TODO: eventually this needs to be done by listening for minion create/destroy events,
@@ -245,26 +221,7 @@ public class ManagerInterfaceHUDElement extends CoreHudWidget implements Control
         }
 
         EntityManager entityManager = CoreRegistry.get(EntityManager.class);
-        //TODO This loop lists out the Oreons that can be summoned
-        /*Iterable<EntityRef> entityIterable = entityManager.getEntitiesWith(MinionComponent.class);
-        for (EntityRef entityRef : entityIterable) {
-
-            MinionComponent minionComponent = entityRef.getComponent(MinionComponent.class);
-
-            String minionIdentity = minionComponent.flavortext + " - " + minionComponent.name;
-
-            UIToggleButton existingMinionMenuItem = new UIToggleButton();
-            existingMinionMenuItem.setText(minionIdentity);
-            existingMinionMenuItem.subscribe(new ActivateEventListener() {
-                @Override
-                public void onActivated(UIWidget widget) {
-                    selectToggleButtonInColumnLayout(creatureTab, widget);
-                    // Go to minion? select minion?
-                }
-            });
-
-            creatureTabColumnLayout.addWidget(existingMinionMenuItem);
-        }*/
+        //TODO A loop which lists out the Oreons that can be summoned
     }
 
     private void selectToggleButtonInColumnLayout(UIWidget layoutWidget, UIWidget selectedToggleButtonWidget) {

--- a/src/main/java/org/terasology/managerInterface/nui/ManagerInterfaceHUDElement.java
+++ b/src/main/java/org/terasology/managerInterface/nui/ManagerInterfaceHUDElement.java
@@ -26,8 +26,8 @@ import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.prefab.PrefabManager;
 import org.terasology.managerInterface.ManagerInterfaceSystem;
-import org.terasology.miniion.components.MinionComponent;
-import org.terasology.miniion.nui.layers.SummonMinionMenuSystem;
+//import org.terasology.miniion.components.MinionComponent;
+//import org.terasology.miniion.nui.layers.SummonMinionMenuSystem;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.nui.AbstractWidget;
 import org.terasology.rendering.nui.ControlWidget;
@@ -208,7 +208,8 @@ public class ManagerInterfaceHUDElement extends CoreHudWidget implements Control
 
         PrefabManager prefMan = CoreRegistry.get(PrefabManager.class);
 
-        for (final Prefab prefab : prefMan.listPrefabs(MinionComponent.class)) {
+        //TODO Implement new MinionComponent and summon logic using Portals, currently SummonMinionMenuSystem has the spawn logic
+        /*for (final Prefab prefab : prefMan.listPrefabs(MinionComponent.class)) {
 
             String[] tempstring = prefab.getName().split(":");
             if (tempstring.length == 2) {
@@ -227,7 +228,7 @@ public class ManagerInterfaceHUDElement extends CoreHudWidget implements Control
 
                 summonTabColumnLayout.addWidget(selectMinionMenu);
             }
-        }
+        }*/
     }
 
     // TODO: eventually this needs to be done by listening for minion create/destroy events,
@@ -244,7 +245,8 @@ public class ManagerInterfaceHUDElement extends CoreHudWidget implements Control
         }
 
         EntityManager entityManager = CoreRegistry.get(EntityManager.class);
-        Iterable<EntityRef> entityIterable = entityManager.getEntitiesWith(MinionComponent.class);
+        //TODO This loop lists out the Oreons that can be summoned
+        /*Iterable<EntityRef> entityIterable = entityManager.getEntitiesWith(MinionComponent.class);
         for (EntityRef entityRef : entityIterable) {
 
             MinionComponent minionComponent = entityRef.getComponent(MinionComponent.class);
@@ -262,7 +264,7 @@ public class ManagerInterfaceHUDElement extends CoreHudWidget implements Control
             });
 
             creatureTabColumnLayout.addWidget(existingMinionMenuItem);
-        }
+        }*/
     }
 
     private void selectToggleButtonInColumnLayout(UIWidget layoutWidget, UIWidget selectedToggleButtonWidget) {


### PR DESCRIPTION
Resolves #3 
MasterOfOreon used the Miniion module for `TaskManagementSystem` which assigned tasks to the Oreons and spawning Oreons from the menu. 
To do further, Spawning using `Portals`(Issue #4 ) and a new Task management system.
After merging this Oreon spawn from the Menu will not work, until #4 is sorted out.