### PR TITLE
Oreons' behavior modifications

### DIFF
--- a/assets/behaviors/taskAcquiringOreon.behavior
+++ b/assets/behaviors/taskAcquiringOreon.behavior
@@ -20,11 +20,6 @@
                         },
                         {
                             sequence : [
-                                {
-                                    log : {
-                                        message : "Looking for task"
-                                    }
-                                },
                                 look_for_task
                             ]
 

--- a/assets/behaviors/taskAcquiringOreon.behavior
+++ b/assets/behaviors/taskAcquiringOreon.behavior
@@ -7,24 +7,27 @@
                     "V assignedTaskType == none"
                 ],
                 child: {
-                    sequence : [
+                    dynamic : [
                         {
-                            log : {
-                                message : "No task assigned"
-                            },
-                            lookup: {
-                                tree: "Behaviors:critter"
+                            timeout : {
+                                time : 1,
+                                child : {
+                                    lookup: {
+                                        tree: "Behaviors:critter"
+                                    }
+                                }
                             }
                         },
                         {
-                            timeout: {
-                                time: 0,
-                                child: {
-                                    sequence: [
-                                        look_for_task
-                                    ]
-                                }
-                            }
+                            sequence : [
+                                {
+                                    log : {
+                                        message : "Looking for task"
+                                    }
+                                },
+                                look_for_task
+                            ]
+
                         }
                     ]
                 }

--- a/assets/behaviors/taskAcquiringOreon.behavior
+++ b/assets/behaviors/taskAcquiringOreon.behavior
@@ -1,0 +1,37 @@
+{
+    dynamic : [
+        {
+            guard: {
+                componentPresent: "MasterOfOreon:Task",
+                values: [
+                    "V assignedTask == none"
+                ],
+                child: {
+                    sequence : [
+                        {
+                            lookup: {
+                                tree: "Behaviors:critter"
+                            }
+                        },
+                        {
+                            timeout: {
+                                time: 3,
+                                child: {
+                                    sequence: [
+                                        look_for_task
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            sequence : [
+                move_to,
+                perform_task
+            ]
+        }
+    ]
+}

--- a/assets/behaviors/taskAcquiringOreon.behavior
+++ b/assets/behaviors/taskAcquiringOreon.behavior
@@ -7,10 +7,10 @@
                     "V assignedTaskType == none"
                 ],
                 child: {
-                    dynamic : [
+                    selector : [
                         {
                             timeout : {
-                                time : 1,
+                                time : 10,
                                 child : {
                                     lookup: {
                                         tree: "Behaviors:critter"

--- a/assets/behaviors/taskAcquiringOreon.behavior
+++ b/assets/behaviors/taskAcquiringOreon.behavior
@@ -9,13 +9,16 @@
                 child: {
                     sequence : [
                         {
+                            log : {
+                                message : "No task assigned"
+                            },
                             lookup: {
                                 tree: "Behaviors:critter"
                             }
                         },
                         {
                             timeout: {
-                                time: 3,
+                                time: 0,
                                 child: {
                                     sequence: [
                                         look_for_task

--- a/assets/behaviors/taskAcquiringOreon.behavior
+++ b/assets/behaviors/taskAcquiringOreon.behavior
@@ -4,7 +4,7 @@
             guard: {
                 componentPresent: "MasterOfOreon:Task",
                 values: [
-                    "V assignedTask == none"
+                    "V assignedTaskType == none"
                 ],
                 child: {
                     sequence : [

--- a/assets/prefabs/behaviorNodes/lookForTask.prefab
+++ b/assets/prefabs/behaviorNodes/lookForTask.prefab
@@ -1,0 +1,12 @@
+{
+  "BehaviorNode" : {
+    "action"    : "look_for_task",
+    "name"      : "look_for_task",
+    "displayName" : "LookForATask",
+    "category"  : "work",
+    "shape"     : "rect",
+    "description": "Finds a task for an Oreon if it has been idle.\nSUCCESS / FAILURE: if task is successfully found and assigned.",
+    "color"     : [180, 180, 180, 255],
+    "textColor" : [0, 0, 0, 255]
+  }
+}

--- a/assets/prefabs/behaviorNodes/performTask.prefab
+++ b/assets/prefabs/behaviorNodes/performTask.prefab
@@ -1,0 +1,12 @@
+{
+  "BehaviorNode" : {
+    "action"    : "perform_task",
+    "name"      : "perform_task",
+    "displayName" : "PerformATask",
+    "category"  : "work",
+    "shape"     : "rect",
+    "description": "Performs a particular assigned task.\nSUCCESS / FAILURE: Returns sucess when the task is completed.",
+    "color"     : [180, 180, 180, 255],
+    "textColor" : [0, 0, 0, 255]
+  }
+}

--- a/assets/prefabs/commandShovel.prefab
+++ b/assets/prefabs/commandShovel.prefab
@@ -1,0 +1,17 @@
+{
+    "parent": "engine:iconItem",
+    "DisplayName": {
+        "name": "Command Shovel"
+    },
+    "Item": {
+        "icon": "engine:items#shovel",
+        "usage": "ON_BLOCK"
+    },
+    "PlaySoundAction": {
+        "sounds": "engine:click"
+    },
+    "BlockSelection": {
+        "shouldRender": true
+    },
+    "OnItemActivateSelection": {}
+}

--- a/assets/ui/taskSelectionScreen.ui
+++ b/assets/ui/taskSelectionScreen.ui
@@ -1,0 +1,85 @@
+{
+    "type" : "TaskSelectionScreenLayer",
+    "skin" : "engine:default",
+    "id" : "taskSelectionScreen",
+    "contents" : {
+        "type" : "RelativeLayout",
+        "contents" : [
+            {
+                "type" : "UIBox",
+                "layoutInfo" : {
+                    "width": 500,
+                    "use-content-height": true,
+                    "position-horizontal-center": {},
+                    "position-vertical-center": {}
+                },
+                "content" : {
+                    "type" : "ColumnLayout",
+                    "columns" : 1,
+                    "verticalSpacing" : 16,
+                    "contents" : [
+                        {
+                            "type" : "RowLayout",
+                            "horizontalSpacing" : 16,
+                            "contents" : [
+                                {
+                                    "type" : "ColumnLayout",
+                                    "contents" : [
+                                        {
+                                            "type" : "UILabel",
+                                            "text" : "Tasks",
+                                            "family" : "title"
+                                        },
+                                        {
+                                            "type" : "UIButton",
+                                            "id" : "plantCommandButton",
+                                            "text" : "Plant"
+                                        },
+                                        {
+                                            "type" : "UIButton",
+                                            "id" : "guardCommandButton",
+                                            "text" : "Guard"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type" : "ColumnLayout",
+                                    "contents" : [
+                                        {
+                                            "type" : "UILabel",
+                                            "text" : "Buildings",
+                                            "family" : "title"
+                                        },
+                                        {
+                                            "type" : "UIButton",
+                                            "id" : "hospitalButton",
+                                            "text" : "Hospital"
+                                        },
+                                        {
+                                            "type" : "UIButton",
+                                            "id" : "dinerButton",
+                                            "text" : "Diner"
+                                        }
+                                    ]
+                                }
+
+                            ]
+                        },
+                        {
+                            "type" : "RowLayout",
+                            "contents" : [
+                                {
+                                    "type" : "UIButton",
+                                    "id" : "cancelButton",
+                                    "text" : "Cancel Selection"
+                                }
+                            ]
+                        }
+                    ]
+                }
+
+            }
+        ]
+    }
+
+}

--- a/deltas/Oreons/prefabs/OreonBuilder.prefab
+++ b/deltas/Oreons/prefabs/OreonBuilder.prefab
@@ -1,0 +1,8 @@
+{
+    "Behavior" : {
+        "tree" : "MasterOfOreon:taskAcquiringOreon"
+    },
+    "Task" : {
+        "assignedTask" : "none"
+    }
+}

--- a/deltas/Oreons/prefabs/OreonBuilder.prefab
+++ b/deltas/Oreons/prefabs/OreonBuilder.prefab
@@ -3,6 +3,6 @@
         "tree" : "MasterOfOreon:taskAcquiringOreon"
     },
     "Task" : {
-        "assignedTask" : "none"
+        "assignedTaskType" : "none"
     }
 }

--- a/deltas/Oreons/prefabs/OreonGuard.prefab
+++ b/deltas/Oreons/prefabs/OreonGuard.prefab
@@ -11,16 +11,18 @@
     },
     "Stand" : {
         "animationPool" : [
-            "BuilderIdle",
-            "BuilderShow",
-            "BuilderWave"
+            "GuardIdleSkygaze",
+            "GuardIdleSkygaze",
+            "GuardWave",
+            "GuardShow",
+            "GuardWakeup"
         ]
     },
     "Walk" : {
-        "animationPool" : ["BuilderWalk"]
+        "animationPool" : ["GuardWalk"]
     },
     "Die" : {
-        "animationPool" : ["BuilderDead"]
+        "animationPool" : ["GuardAfraidNonLoop"]
     },
     "CharacterMovement" : {
         "groundFriction" : 16,

--- a/deltas/Oreons/prefabs/OreonKing.prefab
+++ b/deltas/Oreons/prefabs/OreonKing.prefab
@@ -11,16 +11,16 @@
     },
     "Stand" : {
         "animationPool" : [
-            "BuilderIdle",
-            "BuilderShow",
-            "BuilderWave"
+            "KingWalk",
+            "KingWalk",
+            "KingWalk"
         ]
     },
     "Walk" : {
-        "animationPool" : ["BuilderWalk"]
+        "animationPool" : ["KingWalk"]
     },
     "Die" : {
-        "animationPool" : ["BuilderDead"]
+        "animationPool" : ["KingWalk"]
     },
     "CharacterMovement" : {
         "groundFriction" : 16,

--- a/module.txt
+++ b/module.txt
@@ -7,7 +7,8 @@
     "dependencies" : [
         {"id" : "Core", "minVersion" : "2.0.0"},
         {"id" : "Oreons", "minVersion" : "0.2.0"},
-        {"id" : "ChangingBlocks", "minVersion" : "0.1.0"}
+        {"id" : "ChangingBlocks", "minVersion" : "0.1.0"},
+        {"id" : "Behaviors", "minVersion" : "0.2.0"}
     ],
     "isServerSideOnly" : false
 }

--- a/src/main/java/org/terasology/Constants.java
+++ b/src/main/java/org/terasology/Constants.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.spawning;
+package org.terasology;
 
 public class Constants {
     public static final String OREON_BUILDER_PREFAB = "Oreons:OreonBuilder";
@@ -34,4 +34,12 @@ public class Constants {
     public static final String OREON_BUILDER_RESOURCES_LABEL_ID = "oreonBuilderResourcesRequired";
     public static final String OREON_GUARD_RESOURCES_LABEL_ID = "oreonGuardResourcesRequired";
     public static final String OREON_KING_RESOURCES_LABEL_ID = "oreonKingResourcesRequired";
+
+    public static final String PLANT_COMMAND_UI_ID = "plantCommandButton";
+    public static final String GUARD_COMMAND_UI_ID = "guardCommandButton";
+
+    public static final String HOSPITAL_BUTTON_ID = "hospitalButton";
+    public static final String DINER_BUTTON_ID = "dinerButton";
+
+    public static final String CANCEL_BUTTON_ID = "cancelButton";
 }

--- a/src/main/java/org/terasology/holdingSystem/HoldingAuthoritySystem.java
+++ b/src/main/java/org/terasology/holdingSystem/HoldingAuthoritySystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/terasology/holdingSystem/HoldingAuthoritySystem.java
+++ b/src/main/java/org/terasology/holdingSystem/HoldingAuthoritySystem.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.holdingSystem;
+
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.holdingSystem.components.HoldingComponent;
+import org.terasology.logic.behavior.core.Actor;
+import org.terasology.registry.Share;
+import org.terasology.spawning.OreonSpawnComponent;
+
+@RegisterSystem(RegisterMode.AUTHORITY)
+@Share(HoldingAuthoritySystem.class)
+public class HoldingAuthoritySystem extends BaseComponentSystem {
+    public HoldingComponent getOreonHolding (Actor actor) {
+        OreonSpawnComponent oreonSpawnComponent = actor.getComponent(OreonSpawnComponent.class);
+
+        return oreonSpawnComponent.parent.getComponent(HoldingComponent.class);
+    }
+
+}

--- a/src/main/java/org/terasology/holdingSystem/components/HoldingComponent.java
+++ b/src/main/java/org/terasology/holdingSystem/components/HoldingComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/terasology/holdingSystem/components/HoldingComponent.java
+++ b/src/main/java/org/terasology/holdingSystem/components/HoldingComponent.java
@@ -13,12 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.taskSystem;
+package org.terasology.holdingSystem.components;
 
-public class AssignedTaskType {
-    public static final String None = "none";
-    public static final String Plant = "plant";
-    public static final String Build = "build";
-    public static final String Harvest = "harvest";
-    public static final String Guard = "guard";
+import org.terasology.entitySystem.Component;
+import org.terasology.taskSystem.components.TaskComponent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class HoldingComponent implements Component {
+    public List<TaskComponent> availableTasks = new ArrayList<TaskComponent>();
+
+
 }

--- a/src/main/java/org/terasology/holdingSystem/components/HoldingComponent.java
+++ b/src/main/java/org/terasology/holdingSystem/components/HoldingComponent.java
@@ -18,9 +18,9 @@ package org.terasology.holdingSystem.components;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedList;
+import java.util.Queue;
 
 public class HoldingComponent implements Component {
-    public List<EntityRef> availableTasks = new ArrayList<>();
+    public Queue<EntityRef> availableTasks = new LinkedList<>();
 }

--- a/src/main/java/org/terasology/holdingSystem/components/HoldingComponent.java
+++ b/src/main/java/org/terasology/holdingSystem/components/HoldingComponent.java
@@ -16,13 +16,11 @@
 package org.terasology.holdingSystem.components;
 
 import org.terasology.entitySystem.Component;
-import org.terasology.taskSystem.components.TaskComponent;
+import org.terasology.entitySystem.entity.EntityRef;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class HoldingComponent implements Component {
-    public List<TaskComponent> availableTasks = new ArrayList<TaskComponent>();
-
-
+    public List<EntityRef> availableTasks = new ArrayList<>();
 }

--- a/src/main/java/org/terasology/managerInterface/ManagerInterfaceSystem.java
+++ b/src/main/java/org/terasology/managerInterface/ManagerInterfaceSystem.java
@@ -81,6 +81,7 @@ public class ManagerInterfaceSystem extends BaseComponentSystem {
         inventoryManager.giveItem(player, player, entityManager.create(Constants.SELECTION_TOOL_PREFAB));
         inventoryManager.giveItem(player, player, blockItemFactory.newInstance(blockManager.getBlockFamily(Constants.PORTAL_PREFAB), 10));
         player.addComponent(new HoldingComponent());
+        inventoryManager.giveItem(player, player, entityManager.create(Constants.COMMAND_SHOVEL_PREFAB));
     }
 
     @ReceiveEvent

--- a/src/main/java/org/terasology/managerInterface/ManagerInterfaceSystem.java
+++ b/src/main/java/org/terasology/managerInterface/ManagerInterfaceSystem.java
@@ -27,7 +27,6 @@ import org.terasology.holdingSystem.components.HoldingComponent;
 import org.terasology.logic.inventory.InventoryComponent;
 import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
-import org.terasology.logic.selection.ApplyBlockSelectionEvent;
 import org.terasology.managerInterface.nui.ManagerInterfaceHUDElement;
 import org.terasology.managerInterface.nui.ToggleMouseGrabberButton;
 import org.terasology.math.geom.Rect2f;
@@ -35,7 +34,7 @@ import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
 import org.terasology.registry.Share;
 import org.terasology.rendering.nui.NUIManager;
-import org.terasology.spawning.Constants;
+import org.terasology.Constants;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.items.BlockItemFactory;
 

--- a/src/main/java/org/terasology/managerInterface/ManagerInterfaceSystem.java
+++ b/src/main/java/org/terasology/managerInterface/ManagerInterfaceSystem.java
@@ -84,7 +84,7 @@ public class ManagerInterfaceSystem extends BaseComponentSystem {
         inventoryManager.giveItem(player, player, entityManager.create(Constants.COMMAND_SHOVEL_PREFAB));
     }
 
-    @ReceiveEvent
+    /*@ReceiveEvent
     public void onSelection(ApplyBlockSelectionEvent event, EntityRef entity) {
         switch (currentManagerCommandMode) {
             case None:
@@ -96,7 +96,7 @@ public class ManagerInterfaceSystem extends BaseComponentSystem {
             case Dig:
                 break;
         }
-    }
+    }*/
 
     // Higher priority than critical because NUI grabs all input when mouse is released
     @ReceiveEvent(components = ClientComponent.class, priority=250)

--- a/src/main/java/org/terasology/managerInterface/ManagerInterfaceSystem.java
+++ b/src/main/java/org/terasology/managerInterface/ManagerInterfaceSystem.java
@@ -23,6 +23,7 @@ import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.holdingSystem.components.HoldingComponent;
 import org.terasology.logic.inventory.InventoryComponent;
 import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
@@ -79,6 +80,7 @@ public class ManagerInterfaceSystem extends BaseComponentSystem {
         BlockItemFactory blockItemFactory = new BlockItemFactory(entityManager);
         inventoryManager.giveItem(player, player, entityManager.create(Constants.SELECTION_TOOL_PREFAB));
         inventoryManager.giveItem(player, player, blockItemFactory.newInstance(blockManager.getBlockFamily(Constants.PORTAL_PREFAB), 10));
+        player.addComponent(new HoldingComponent());
     }
 
     @ReceiveEvent

--- a/src/main/java/org/terasology/portals/PortalComponent.java
+++ b/src/main/java/org/terasology/portals/PortalComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/terasology/spawning/Constants.java
+++ b/src/main/java/org/terasology/spawning/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/terasology/spawning/Constants.java
+++ b/src/main/java/org/terasology/spawning/Constants.java
@@ -29,6 +29,7 @@ public class Constants {
 
     public static final String SELECTION_TOOL_PREFAB = "MasterOfOreon:selectionTool";
     public static final String PORTAL_PREFAB = "MasterOfOreon:portal";
+    public static final String COMMAND_SHOVEL_PREFAB = "MasterOfOreon:commandShovel";
 
     public static final String OREON_BUILDER_RESOURCES_LABEL_ID = "oreonBuilderResourcesRequired";
     public static final String OREON_GUARD_RESOURCES_LABEL_ID = "oreonGuardResourcesRequired";

--- a/src/main/java/org/terasology/spawning/OreonAttributeComponent.java
+++ b/src/main/java/org/terasology/spawning/OreonAttributeComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/terasology/spawning/OreonSpawnComponent.java
+++ b/src/main/java/org/terasology/spawning/OreonSpawnComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/terasology/spawning/OreonSpawnEvent.java
+++ b/src/main/java/org/terasology/spawning/OreonSpawnEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/terasology/spawning/OreonSpawnEvent.java
+++ b/src/main/java/org/terasology/spawning/OreonSpawnEvent.java
@@ -25,7 +25,8 @@ public class OreonSpawnEvent implements Event {
     private Prefab oreonPrefab;
     private Vector3f location;
 
-    public OreonSpawnEvent () {}
+    public OreonSpawnEvent () {
+    }
 
     public OreonSpawnEvent(Prefab prefab, Vector3f location) {
         this.oreonPrefab = prefab;
@@ -36,7 +37,7 @@ public class OreonSpawnEvent implements Event {
         return this.oreonPrefab;
     }
 
-    public Vector3f getSpawnPos() {
+    public Vector3f getSpawnPosition() {
         return this.location;
     }
 }

--- a/src/main/java/org/terasology/spawning/SpawningAuthoritySystem.java
+++ b/src/main/java/org/terasology/spawning/SpawningAuthoritySystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/terasology/spawning/SpawningAuthoritySystem.java
+++ b/src/main/java/org/terasology/spawning/SpawningAuthoritySystem.java
@@ -28,8 +28,6 @@ import org.terasology.logic.inventory.InventoryComponent;
 import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.logic.players.PlayerUtil;
 import org.terasology.math.geom.Vector3f;
-import org.terasology.minion.move.MinionMoveComponent;
-import org.terasology.navgraph.WalkableBlock;
 import org.terasology.network.NetworkComponent;
 import org.terasology.registry.In;
 import org.terasology.utilities.random.MersenneRandom;

--- a/src/main/java/org/terasology/spawning/SpawningAuthoritySystem.java
+++ b/src/main/java/org/terasology/spawning/SpawningAuthoritySystem.java
@@ -28,6 +28,8 @@ import org.terasology.logic.inventory.InventoryComponent;
 import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.logic.players.PlayerUtil;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.minion.move.MinionMoveComponent;
+import org.terasology.navgraph.WalkableBlock;
 import org.terasology.network.NetworkComponent;
 import org.terasology.registry.In;
 import org.terasology.utilities.random.MersenneRandom;
@@ -52,7 +54,7 @@ public class SpawningAuthoritySystem extends BaseComponentSystem {
     private InventoryManager inventoryManager;
 
     private Prefab prefabToSpawn;
-    private Vector3f spawnPos;
+    private Vector3f spawnPosition;
 
 
     /**
@@ -61,13 +63,12 @@ public class SpawningAuthoritySystem extends BaseComponentSystem {
     @ReceiveEvent
     public void oreonSpawn(OreonSpawnEvent event, EntityRef player) {
         prefabToSpawn = event.getOreonPrefab();
-        spawnPos = event.getSpawnPos();
-        spawnPos.y -= 0.5f;
+        spawnPosition = event.getSpawnPosition();
 
         boolean shouldSpawn = consumeItem(player, prefabToSpawn);
         if (shouldSpawn) {
             // spawn the new oreon into the world
-            EntityRef newOreon = entityManager.create(prefabToSpawn, spawnPos);
+            EntityRef newOreon = entityManager.create(prefabToSpawn, spawnPosition);
             NetworkComponent networkComponent = new NetworkComponent();
             networkComponent.replicateMode = NetworkComponent.ReplicateMode.ALWAYS;
             newOreon.addComponent(networkComponent);
@@ -75,7 +76,7 @@ public class SpawningAuthoritySystem extends BaseComponentSystem {
 
             assignRandomAttributes(newOreon);
 
-            logger.info("Player " + PlayerUtil.getColoredPlayerName(player.getOwner()) + " spawned a new Oreon of Type : " + prefabToSpawn.getName());
+            logger.info("Player " + PlayerUtil.getColoredPlayerName(player) + " spawned a new Oreon of Type : " + prefabToSpawn.getName());
         }
     }
 

--- a/src/main/java/org/terasology/spawning/SpawningAuthoritySystem.java
+++ b/src/main/java/org/terasology/spawning/SpawningAuthoritySystem.java
@@ -17,6 +17,7 @@ package org.terasology.spawning;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.Constants;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;

--- a/src/main/java/org/terasology/spawning/SpawningClientSystem.java
+++ b/src/main/java/org/terasology/spawning/SpawningClientSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/terasology/spawning/nui/SpawnScreenLayer.java
+++ b/src/main/java/org/terasology/spawning/nui/SpawnScreenLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/terasology/spawning/nui/SpawnScreenLayer.java
+++ b/src/main/java/org/terasology/spawning/nui/SpawnScreenLayer.java
@@ -28,7 +28,7 @@ import org.terasology.registry.In;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.widgets.UIButton;
 import org.terasology.rendering.nui.widgets.UILabel;
-import org.terasology.spawning.Constants;
+import org.terasology.Constants;
 import org.terasology.spawning.OreonSpawnComponent;
 import org.terasology.spawning.OreonSpawnEvent;
 

--- a/src/main/java/org/terasology/taskSystem/AssignedTaskType.java
+++ b/src/main/java/org/terasology/taskSystem/AssignedTaskType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/terasology/taskSystem/AssignedTaskType.java
+++ b/src/main/java/org/terasology/taskSystem/AssignedTaskType.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.taskSystem;
+
+public class AssignedTaskType {
+    public static final String None = "none";
+    public static final String Plant = "plant";
+    public static final String Build = "build";
+    public static final String Harvest = "harvest";
+    public static final String Guard = "Guard";
+}

--- a/src/main/java/org/terasology/taskSystem/BuildingType.java
+++ b/src/main/java/org/terasology/taskSystem/BuildingType.java
@@ -13,18 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.taskSystem.components;
+package org.terasology.taskSystem;
 
-import org.terasology.entitySystem.Component;
-import org.terasology.math.Region3i;
-import org.terasology.taskSystem.BuildingType;
-import org.terasology.taskSystem.TaskStatusType;
-
-public class TaskComponent implements Component {
-    public String assignedTaskType;
-    public long creationTime;
-    public TaskStatusType taskStatus;
-    public BuildingType buildingType;
-
-    public Region3i taskRegion;
+public enum BuildingType {
+    Hospital,
+    Diner,
+    Gym
 }

--- a/src/main/java/org/terasology/taskSystem/TaskManagementSystem.java
+++ b/src/main/java/org/terasology/taskSystem/TaskManagementSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/terasology/taskSystem/TaskManagementSystem.java
+++ b/src/main/java/org/terasology/taskSystem/TaskManagementSystem.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.taskSystem;
+
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.holdingSystem.components.HoldingComponent;
+import org.terasology.logic.behavior.core.Actor;
+import org.terasology.registry.Share;
+import org.terasology.taskSystem.components.TaskComponent;
+
+import java.util.List;
+
+@Share(TaskManagementSystem.class)
+@RegisterSystem(RegisterMode.AUTHORITY)
+public class TaskManagementSystem extends BaseComponentSystem {
+    public boolean getTaskForOreon(HoldingComponent oreonHolding, Actor oreon) {
+        List<TaskComponent> availableTasks = oreonHolding.availableTasks;
+        //TODO sort List by creationTime
+
+        if(!availableTasks.isEmpty()) {
+            TaskComponent oreonTaskComponent = oreon.getComponent(TaskComponent.class);
+            TaskComponent availableTaskComponent = availableTasks.remove(0);
+
+            oreonTaskComponent.assignedTaskType = availableTaskComponent.assignedTaskType;
+            oreonTaskComponent.creationTime = availableTaskComponent.creationTime;
+
+            oreon.save(oreonTaskComponent);
+            availableTaskComponent.taskStatus = TaskStatusType.InProgress;
+            return true;
+        }
+
+        return false;
+    }
+
+    public void addTask(HoldingComponent oreonHolding, TaskComponent taskComponent) {
+        taskComponent.taskStatus = TaskStatusType.Available;
+        oreonHolding.availableTasks.add(taskComponent);
+    }
+}

--- a/src/main/java/org/terasology/taskSystem/TaskManagementSystem.java
+++ b/src/main/java/org/terasology/taskSystem/TaskManagementSystem.java
@@ -39,6 +39,7 @@ import org.terasology.taskSystem.events.SetTaskTypeEvent;
 import org.terasology.world.selection.BlockSelectionComponent;
 
 import java.util.List;
+import java.util.Queue;
 
 @Share(TaskManagementSystem.class)
 @RegisterSystem(RegisterMode.AUTHORITY)
@@ -64,12 +65,10 @@ public class TaskManagementSystem extends BaseComponentSystem {
     }
 
     public boolean getTaskForOreon(Actor oreon) {
-        List<EntityRef> availableTasks = oreonHolding.availableTasks;
+        Queue<EntityRef> availableTasks = oreonHolding.availableTasks;
         logger.debug("Looking for task in " + oreonHolding);
         if (!availableTasks.isEmpty()) {
-            //TODO sort list by creationTime
-
-            EntityRef taskEntity = availableTasks.remove(0);
+            EntityRef taskEntity = availableTasks.remove();
             TaskComponent taskComponent = taskEntity.getComponent(TaskComponent.class);
 
             TaskComponent oreonTaskComponent = oreon.getComponent(TaskComponent.class);

--- a/src/main/java/org/terasology/taskSystem/TaskStatusType.java
+++ b/src/main/java/org/terasology/taskSystem/TaskStatusType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/terasology/taskSystem/TaskStatusType.java
+++ b/src/main/java/org/terasology/taskSystem/TaskStatusType.java
@@ -15,10 +15,8 @@
  */
 package org.terasology.taskSystem;
 
-public class AssignedTaskType {
-    public static final String None = "none";
-    public static final String Plant = "plant";
-    public static final String Build = "build";
-    public static final String Harvest = "harvest";
-    public static final String Guard = "guard";
+public enum TaskStatusType {
+    Available,
+    InProgress,
+    Completed
 }

--- a/src/main/java/org/terasology/taskSystem/actions/LookForTaskNode.java
+++ b/src/main/java/org/terasology/taskSystem/actions/LookForTaskNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/terasology/taskSystem/actions/LookForTaskNode.java
+++ b/src/main/java/org/terasology/taskSystem/actions/LookForTaskNode.java
@@ -15,9 +15,39 @@
  */
 package org.terasology.taskSystem.actions;
 
+import org.terasology.holdingSystem.HoldingAuthoritySystem;
+import org.terasology.holdingSystem.components.HoldingComponent;
 import org.terasology.logic.behavior.BehaviorAction;
+import org.terasology.logic.behavior.core.Actor;
 import org.terasology.logic.behavior.core.BaseAction;
+import org.terasology.logic.behavior.core.BehaviorState;
+import org.terasology.registry.In;
+import org.terasology.taskSystem.TaskManagementSystem;
+import org.terasology.taskSystem.components.TaskComponent;
 
 @BehaviorAction(name = "look_for_task")
 public class LookForTaskNode extends BaseAction {
+    @In
+    HoldingAuthoritySystem holdingSystem;
+
+    @In
+    TaskManagementSystem taskManagementSystem;
+
+    HoldingComponent oreonHolding;
+    TaskComponent oreonTaskComponent;
+
+    @Override
+    public void construct (Actor actor) {
+        oreonHolding = holdingSystem.getOreonHolding(actor);
+        oreonTaskComponent = actor.getComponent(TaskComponent.class);
+    }
+
+    @Override
+    public BehaviorState modify (Actor actor, BehaviorState result) {
+        if (taskManagementSystem.getTaskForOreon(oreonHolding, actor)) {
+            return BehaviorState.SUCCESS;
+        }
+
+        return BehaviorState.FAILURE;
+    }
 }

--- a/src/main/java/org/terasology/taskSystem/actions/LookForTaskNode.java
+++ b/src/main/java/org/terasology/taskSystem/actions/LookForTaskNode.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.taskSystem.actions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.holdingSystem.HoldingAuthoritySystem;
 import org.terasology.holdingSystem.components.HoldingComponent;
 import org.terasology.logic.behavior.BehaviorAction;
@@ -23,28 +25,27 @@ import org.terasology.logic.behavior.core.BaseAction;
 import org.terasology.logic.behavior.core.BehaviorState;
 import org.terasology.registry.In;
 import org.terasology.taskSystem.TaskManagementSystem;
-import org.terasology.taskSystem.components.TaskComponent;
 
 @BehaviorAction(name = "look_for_task")
 public class LookForTaskNode extends BaseAction {
+    private static final Logger logger = LoggerFactory.getLogger(LookForTaskNode.class);
     @In
-    HoldingAuthoritySystem holdingSystem;
+    private HoldingAuthoritySystem holdingSystem;
 
     @In
-    TaskManagementSystem taskManagementSystem;
+    private TaskManagementSystem taskManagementSystem;
 
-    HoldingComponent oreonHolding;
-    TaskComponent oreonTaskComponent;
+    private HoldingComponent oreonHolding;
 
     @Override
-    public void construct (Actor actor) {
-        oreonHolding = holdingSystem.getOreonHolding(actor);
-        oreonTaskComponent = actor.getComponent(TaskComponent.class);
+    public void construct (Actor oreon) {
+        oreonHolding = holdingSystem.getOreonHolding(oreon);
+        taskManagementSystem.setOreonHolding(oreonHolding);
     }
 
     @Override
-    public BehaviorState modify (Actor actor, BehaviorState result) {
-        if (taskManagementSystem.getTaskForOreon(oreonHolding, actor)) {
+    public BehaviorState modify (Actor oreon, BehaviorState result) {
+        if (taskManagementSystem.getTaskForOreon(oreon)) {
             return BehaviorState.SUCCESS;
         }
 

--- a/src/main/java/org/terasology/taskSystem/actions/LookForTaskNode.java
+++ b/src/main/java/org/terasology/taskSystem/actions/LookForTaskNode.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.taskSystem.actions;
+
+import org.terasology.logic.behavior.BehaviorAction;
+import org.terasology.logic.behavior.core.BaseAction;
+
+@BehaviorAction(name = "look_for_task")
+public class LookForTaskNode extends BaseAction {
+}

--- a/src/main/java/org/terasology/taskSystem/actions/LookForTaskNode.java
+++ b/src/main/java/org/terasology/taskSystem/actions/LookForTaskNode.java
@@ -23,22 +23,22 @@ import org.terasology.logic.behavior.BehaviorAction;
 import org.terasology.logic.behavior.core.Actor;
 import org.terasology.logic.behavior.core.BaseAction;
 import org.terasology.logic.behavior.core.BehaviorState;
-import org.terasology.registry.In;
+import org.terasology.registry.CoreRegistry;
 import org.terasology.taskSystem.TaskManagementSystem;
 
 @BehaviorAction(name = "look_for_task")
 public class LookForTaskNode extends BaseAction {
     private static final Logger logger = LoggerFactory.getLogger(LookForTaskNode.class);
-    @In
-    private HoldingAuthoritySystem holdingSystem;
 
-    @In
+    private HoldingAuthoritySystem holdingSystem;
     private TaskManagementSystem taskManagementSystem;
 
     private HoldingComponent oreonHolding;
 
     @Override
     public void construct (Actor oreon) {
+        this.holdingSystem = CoreRegistry.get(HoldingAuthoritySystem.class);
+        this.taskManagementSystem = CoreRegistry.get(TaskManagementSystem.class);
         oreonHolding = holdingSystem.getOreonHolding(oreon);
         taskManagementSystem.setOreonHolding(oreonHolding);
     }

--- a/src/main/java/org/terasology/taskSystem/actions/PerformTaskNode.java
+++ b/src/main/java/org/terasology/taskSystem/actions/PerformTaskNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/terasology/taskSystem/actions/PerformTaskNode.java
+++ b/src/main/java/org/terasology/taskSystem/actions/PerformTaskNode.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.taskSystem.actions;
+
+import org.terasology.logic.behavior.BehaviorAction;
+import org.terasology.logic.behavior.core.BaseAction;
+
+@BehaviorAction(name = "perform_task")
+public class PerformTaskNode extends BaseAction {
+}

--- a/src/main/java/org/terasology/taskSystem/actions/PerformTaskNode.java
+++ b/src/main/java/org/terasology/taskSystem/actions/PerformTaskNode.java
@@ -30,14 +30,14 @@ public class PerformTaskNode extends BaseAction {
 
     @Override
     public BehaviorState modify (Actor actor, BehaviorState result) {
-        logger.debug("Perfoming Task");
+        TaskComponent oreonTaskComponent = actor.getComponent(TaskComponent.class);
+        logger.info("Perfoming Task of type : " + oreonTaskComponent.assignedTaskType);
 
         //free the Oreon after perfoming task
-        TaskComponent oreonTaskComponent = actor.getComponent(TaskComponent.class);
         oreonTaskComponent.assignedTaskType = AssignedTaskType.None;
         actor.save(oreonTaskComponent);
 
-        logger.debug("Task completed, the Oreon is now free!");
+        logger.info("Task completed, the Oreon is now free!");
 
         return BehaviorState.SUCCESS;
     }

--- a/src/main/java/org/terasology/taskSystem/actions/PerformTaskNode.java
+++ b/src/main/java/org/terasology/taskSystem/actions/PerformTaskNode.java
@@ -21,6 +21,8 @@ import org.terasology.logic.behavior.BehaviorAction;
 import org.terasology.logic.behavior.core.Actor;
 import org.terasology.logic.behavior.core.BaseAction;
 import org.terasology.logic.behavior.core.BehaviorState;
+import org.terasology.taskSystem.AssignedTaskType;
+import org.terasology.taskSystem.components.TaskComponent;
 
 @BehaviorAction(name = "perform_task")
 public class PerformTaskNode extends BaseAction {
@@ -28,7 +30,14 @@ public class PerformTaskNode extends BaseAction {
 
     @Override
     public BehaviorState modify (Actor actor, BehaviorState result) {
-        logger.info("Perfoming Task");
+        logger.debug("Perfoming Task");
+
+        //free the Oreon after perfoming task
+        TaskComponent oreonTaskComponent = actor.getComponent(TaskComponent.class);
+        oreonTaskComponent.assignedTaskType = AssignedTaskType.None;
+        actor.save(oreonTaskComponent);
+
+        logger.debug("Task completed, the Oreon is now free!");
 
         return BehaviorState.SUCCESS;
     }

--- a/src/main/java/org/terasology/taskSystem/actions/PerformTaskNode.java
+++ b/src/main/java/org/terasology/taskSystem/actions/PerformTaskNode.java
@@ -15,9 +15,26 @@
  */
 package org.terasology.taskSystem.actions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.logic.behavior.BehaviorAction;
+import org.terasology.logic.behavior.core.Actor;
 import org.terasology.logic.behavior.core.BaseAction;
+import org.terasology.logic.behavior.core.BehaviorState;
 
 @BehaviorAction(name = "perform_task")
 public class PerformTaskNode extends BaseAction {
+    private static final Logger logger = LoggerFactory.getLogger(PerformTaskNode.class);
+
+    @Override
+    public BehaviorState modify (Actor actor, BehaviorState result) {
+        logger.info("Perfoming Task");
+
+        try { Thread.sleep(1000);}
+        catch(InterruptedException e) {
+            logger.info("interrupted");
+        }
+
+        return BehaviorState.SUCCESS;
+    }
 }

--- a/src/main/java/org/terasology/taskSystem/actions/PerformTaskNode.java
+++ b/src/main/java/org/terasology/taskSystem/actions/PerformTaskNode.java
@@ -30,11 +30,6 @@ public class PerformTaskNode extends BaseAction {
     public BehaviorState modify (Actor actor, BehaviorState result) {
         logger.info("Perfoming Task");
 
-        try { Thread.sleep(1000);}
-        catch(InterruptedException e) {
-            logger.info("interrupted");
-        }
-
         return BehaviorState.SUCCESS;
     }
 }

--- a/src/main/java/org/terasology/taskSystem/components/TaskComponent.java
+++ b/src/main/java/org/terasology/taskSystem/components/TaskComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/terasology/taskSystem/components/TaskComponent.java
+++ b/src/main/java/org/terasology/taskSystem/components/TaskComponent.java
@@ -16,7 +16,10 @@
 package org.terasology.taskSystem.components;
 
 import org.terasology.entitySystem.Component;
+import org.terasology.taskSystem.TaskStatusType;
 
 public class TaskComponent implements Component {
-    public String assignedTask;
+    public String assignedTaskType;
+    public long creationTime;
+    public TaskStatusType taskStatus;
 }

--- a/src/main/java/org/terasology/taskSystem/components/TaskComponent.java
+++ b/src/main/java/org/terasology/taskSystem/components/TaskComponent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.taskSystem.components;
+
+import org.terasology.entitySystem.Component;
+
+public class TaskComponent implements Component {
+    public String assignedTask;
+}

--- a/src/main/java/org/terasology/taskSystem/components/TaskComponent.java
+++ b/src/main/java/org/terasology/taskSystem/components/TaskComponent.java
@@ -16,10 +16,13 @@
 package org.terasology.taskSystem.components;
 
 import org.terasology.entitySystem.Component;
+import org.terasology.math.Region3i;
 import org.terasology.taskSystem.TaskStatusType;
 
 public class TaskComponent implements Component {
     public String assignedTaskType;
     public long creationTime;
     public TaskStatusType taskStatus;
+
+    public Region3i taskRegion;
 }

--- a/src/main/java/org/terasology/taskSystem/events/SetTaskTypeEvent.java
+++ b/src/main/java/org/terasology/taskSystem/events/SetTaskTypeEvent.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.taskSystem.events;
+
+import org.terasology.entitySystem.event.Event;
+import org.terasology.taskSystem.BuildingType;
+
+public class SetTaskTypeEvent implements Event {
+    private String taskType;
+    private BuildingType buildingType;
+
+    public SetTaskTypeEvent () {
+
+    }
+
+    public SetTaskTypeEvent (String assignedTaskType) {
+        this.taskType = assignedTaskType;
+    }
+
+    public SetTaskTypeEvent (String assignedTaskType, BuildingType buildingType) {
+        this.taskType = assignedTaskType;
+        this.buildingType = buildingType;
+    }
+
+    public String getTaskType() {
+        return taskType;
+    }
+
+    public BuildingType getBuildingType() {
+        return buildingType;
+    }
+}

--- a/src/main/java/org/terasology/taskSystem/nui/TaskSelectionScreenLayer.java
+++ b/src/main/java/org/terasology/taskSystem/nui/TaskSelectionScreenLayer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.taskSystem.nui;
+
+import org.terasology.Constants;
+import org.terasology.logic.players.LocalPlayer;
+import org.terasology.registry.In;
+import org.terasology.rendering.nui.CoreScreenLayer;
+import org.terasology.rendering.nui.NUIManager;
+import org.terasology.rendering.nui.widgets.UIButton;
+import org.terasology.taskSystem.AssignedTaskType;
+import org.terasology.taskSystem.BuildingType;
+import org.terasology.taskSystem.events.SetTaskTypeEvent;
+
+public class TaskSelectionScreenLayer extends CoreScreenLayer {
+    @In
+    private LocalPlayer localPlayer;
+
+    @In
+    private NUIManager nuiManager;
+
+    private UIButton plantCommand;
+    private UIButton guardCommand;
+
+    private UIButton hospitalButton;
+    private UIButton dinerButton;
+
+    private UIButton cancelButton;
+
+    @Override
+    public void initialise() {
+        plantCommand = find(Constants.PLANT_COMMAND_UI_ID, UIButton.class);
+        guardCommand = find(Constants.GUARD_COMMAND_UI_ID, UIButton.class);
+
+        hospitalButton = find(Constants.HOSPITAL_BUTTON_ID, UIButton.class);
+        dinerButton = find(Constants.DINER_BUTTON_ID, UIButton.class);
+
+        cancelButton = find(Constants.CANCEL_BUTTON_ID, UIButton.class);
+
+        plantCommand.subscribe(button -> {
+            sendSetTaskTypeEvent(AssignedTaskType.Plant);
+        });
+
+        guardCommand.subscribe(button -> {
+            sendSetTaskTypeEvent(AssignedTaskType.Guard);
+        });
+
+        hospitalButton.subscribe(button -> {
+            sendSetTaskTypeEvent(AssignedTaskType.Build, BuildingType.Hospital);
+        });
+
+        dinerButton.subscribe(button -> {
+            sendSetTaskTypeEvent(AssignedTaskType.Build, BuildingType.Diner);
+        });
+
+        cancelButton.subscribe(button -> {
+            sendSetTaskTypeEvent();
+        });
+    }
+
+    public void sendSetTaskTypeEvent () {
+        localPlayer.getCharacterEntity().send(new SetTaskTypeEvent());
+    }
+
+    public void sendSetTaskTypeEvent(String assignedTaskType) {
+        localPlayer.getCharacterEntity().send(new SetTaskTypeEvent(assignedTaskType));
+    }
+
+    public void sendSetTaskTypeEvent (String assignedTaskType, BuildingType buildingType) {
+        localPlayer.getCharacterEntity().send(new SetTaskTypeEvent(assignedTaskType, buildingType));
+    }
+}


### PR DESCRIPTION
Work done so far include : 
- Modified Oreon prefabs and behaviors in the Oreons module. Oreons spawned directly from that module show idling behavior(~changes in this Oreons [PR](https://github.com/Terasology/Oreons/pull/4)~ closed this PR, the changes made to the prefabs are now moved to `deltas` in MOO)
- Added a `taskAcquiring` behavior in MOO for Oreons(currently only for OreonBuilder), the Oreon `critter`s and looks for task every second.
- The command shovel can be used to select an area which triggers an event and stores the task in the Holding attached to the player.
- An Oreon looking for tasks finds it in the Holding and walks to it, then the node `perform_task` is executed which currently just logs "performing task"

Outstanding before merge : 
- [x] Delete some logger statements which log messages every tick when the BT is run.
- [x] Set the Oreon task to `none` after performing task, so that the Behavior is again changed to `critter`