### PR TITLE
Check area before assigning build task

### DIFF
--- a/assets/ui/notificationOverlayMOO.ui
+++ b/assets/ui/notificationOverlayMOO.ui
@@ -18,7 +18,7 @@
                      }
                 ],
                 "layoutInfo": {
-                         "width" : 500,
+                         "width" : 600,
                          "height" : 40,
                          "position-horizontal-left" : {},
                          "position-vertical-left" : {}


### PR DESCRIPTION
This PR introduces a feature which enables the player to visualize the area required by a building before finalizing it. As soon as the player selects a build task, the area of the building floor is dispalyed and this area moves with the camera. The player can then finalize a location for the building by clicking the left mouse button.

### To test:
- Start the game, start a block selection and assign a build task.
- Move the camera around and the area selection should move accordingly.
- Click the left mouse button to finalize an area for the building construction.