### PR TITLE
Pathfinding fix

### DIFF
--- a/assets/behaviors/taskAcquiringOreon.behavior
+++ b/assets/behaviors/taskAcquiringOreon.behavior
@@ -36,9 +36,7 @@
         {
             "sequence" : [
                 {
-                    "move_to": {
-                        "distance": 1.5
-                    }
+                    "lookup" : {"tree":"Behaviors:pointPathfindingFollow"}
                 },
                 {
                     "selector" : [

--- a/assets/behaviors/taskAcquiringOreon.behavior
+++ b/assets/behaviors/taskAcquiringOreon.behavior
@@ -10,7 +10,7 @@
                     "selector" : [
                         {
                             "timeout" : {
-                                "time" : 10,
+                                "time" : 1,
                                 "child" : {
                                     "lookup" : {
                                         "tree" : "Behaviors:critter"
@@ -36,7 +36,36 @@
         {
             "sequence" : [
                 {
-                    "lookup" : {"tree":"Behaviors:pointPathfindingFollow"}
+                    "sequence": [
+                        {
+                            "animation" : {
+                                "play": "engine:Walk.animationPool",
+                                "loop": "engine:Walk.animationPool"
+                            }
+                        },
+                        {
+                            "set_speed" : {
+                                "speedMultiplier" : 0.8
+                            }
+                        },
+                        {
+                            "sequence" : [
+                                {
+                                    "find_path" : {}
+                                },
+                                {
+                                    "move_along_path" : {
+                                        "child" : {
+                                            "move_to" : {
+                                                "distance" : 1.0
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+
+                        }
+                    ]
                 },
                 {
                     "selector" : [

--- a/src/main/java/org/terasology/taskSystem/TaskManagementSystem.java
+++ b/src/main/java/org/terasology/taskSystem/TaskManagementSystem.java
@@ -502,6 +502,7 @@ public class TaskManagementSystem extends BaseComponentSystem {
         MinionMoveComponent moveComponent = oreon.getComponent(MinionMoveComponent.class);
 
         moveComponent.target = new Vector3f(target.x, target.y, target.z);
+        moveComponent.type = MinionMoveComponent.Type.DIRECT;
 
         logger.info("Set Oreon target to : " + moveComponent.target);
 


### PR DESCRIPTION
Fixes the bug in the Oreon BT, so they look for a path before walking to a task area.

#### Steps to test:
- Add multiple tasks and then spawn an Oreon. Add multiple construction(preferably storage, as it finishes construction instantly) tasks so that the Oreon has a challenge.

#### Bugs to resolve:
- [ ] Oreon stuck at walking animation even when performing a task