### PR TITLE
fix: add default world generator

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -26,5 +26,6 @@
         { "id": "WorldlyTooltipAPI", "minVersion": "1.0.0" }
     ],
     "isServerSideOnly": false,
-    "isGameplay": true
+    "isGameplay": true,
+    "defaultWorldGenerator": "CoreWorlds:FacetedSimplex"
 }


### PR DESCRIPTION
**Problem:** I just tried to start MOO, got "Failed to resolve world generator", checked the logs and saw the following:
```log
16:08:41.443 [main] ERROR o.t.e.m.l.InitialiseWorld - Unable to load world generator MetalRenegades:dynamicWorld. Available world generators: [Flat (CoreWorlds:flat), Height Map (CoreWorlds:heightMap), Pathfinder TestWorld (Pathfinding:pathfinder), Perlin (CoreWorlds:facetedperlin), Simplex (CoreWorlds:facetedsimplex), dummy (ModuleTestingEnvironment:dummy), empty (ModuleTestingEnvironment:empty)]
```
Why the heck would it try to load `MetalRenegades:dynamicWorld` if I select MOO to start? 🤔 
MOO doesn't have a default world generator... maybe it then just tries to use the one that was last used 🤯 

**Solution:** Define a default world generator.